### PR TITLE
update import to use new importlib.resources (pkg_resources is deprecated)

### DIFF
--- a/dfloat11_decompress.py
+++ b/dfloat11_decompress.py
@@ -1,5 +1,5 @@
 import cupy as cp
-import pkg_resources
+from importlib.resources import files
 import math
 
 import torch
@@ -7,7 +7,7 @@ import torch
 from dfloat11.dfloat11 import TensorManager
 import gc
 
-ptx_path = pkg_resources.resource_filename("dfloat11", "decode.ptx")
+ptx_path = str(files("dfloat11").joinpath("decode.ptx"))
 _decode = cp.RawModule(path=ptx_path).get_function('decode')
 
 bytes_per_thread = 8

--- a/dfloat11_diffusers.py
+++ b/dfloat11_diffusers.py
@@ -1,5 +1,5 @@
 import cupy as cp
-import pkg_resources
+from importlib.resources import files
 import re
 import math
 import uuid
@@ -29,7 +29,7 @@ from dfloat11.dfloat11_utils import get_codec, get_32bit_codec, get_luts, encode
 
 from .convert_fixed_tensors import convert_diffusers_to_comfyui_flux
 
-ptx_path = pkg_resources.resource_filename("dfloat11", "decode.ptx")
+ptx_path = str(files("dfloat11").joinpath("decode.ptx"))
 _decode = cp.RawModule(path=ptx_path).get_function('decode')
 
 


### PR DESCRIPTION
like the title says.
This is now needed as the latest version of setuptools has effectively deprecated the function (doesn't exist anymore)
This change will also require the main dfloat11 library to have a similar update (which I did locally).
Maybe you could publish your own dfloat11 python package?
